### PR TITLE
prometheus_speedtest: Add multi-arch images with Docker buildx.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,22 @@ pylint **/*.py
    twine upload dist/*
    ```
 
+### Deploying multi-architecture images to Docker Hub
+
+1. Ensure that Docker >= 19.03 and
+   [docker buildx](https://docs.docker.com/buildx/working-with-buildx/) is
+   installed.
+
+1. Build and push the new image.
+
+   ```shell
+   # Ensure you have run 'docker login'
+   export DOCKER_CLI_EXPERIMENTAL=enabled
+   docker buildx create --use --name my-builder
+   docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 \
+       -t jraviles/prometheus_speedtest:latest .
+   ```
+
 ## Authors
 
 * Jean-Ralph Aviles


### PR DESCRIPTION
Closes #12.

The Docker image now supports linux/amd64, linux/arm64, and linux/arm/v7.

![image](https://user-images.githubusercontent.com/5875882/74009130-68e3a600-4937-11ea-80be-635219aec954.png)


