### PR TITLE
add possibility to specify server-id

### DIFF
--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -16,14 +16,14 @@ from prometheus_speedtest import version
 
 flags.DEFINE_string('address', '0.0.0.0', 'address to listen on')
 flags.DEFINE_integer('port', 9516, 'port to listen on')
-flags.DEFINE_multi_integer('servers', [], 'speedtest server(s) to use - leave empty for auto-selection')
+flags.DEFINE_list('servers', None, 'speedtest server(s) to use - leave empty for auto-selection')
 flags.DEFINE_boolean('version', False, 'show version')
 FLAGS = flags.FLAGS
 
 
 class PrometheusSpeedtest():
     """Enapsulates behavior performing and reporting results of speedtests."""
-    def __init__(self, source_address=None, timeout=10, servers=[]):
+    def __init__(self, source_address=None, timeout=10, servers=None):
         """Instantiates a PrometheusSpeedtest object.
 
         Args:
@@ -54,7 +54,7 @@ class PrometheusSpeedtest():
 
 class SpeedtestCollector():
     """Performs Speedtests when requested from Prometheus."""
-    def __init__(self, tester=None, servers=[]):
+    def __init__(self, tester=None, servers=None):
         """Instantiates a SpeedtestCollector object.
 
         Args:

--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -45,7 +45,7 @@ class PrometheusSpeedtest():
         client = speedtest.Speedtest(source_address=self._source_address,
                                      timeout=self._timeout)
         if self._server > 0:
-            client.get_servers(servers=self._server)
+            client.get_servers(servers=[self._server])
         client.get_best_server()
         client.download()
         client.upload()

--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -16,13 +16,14 @@ from prometheus_speedtest import version
 
 flags.DEFINE_string('address', '0.0.0.0', 'address to listen on')
 flags.DEFINE_integer('port', 9516, 'port to listen on')
+flags.DEFINE_integer('server', 0, 'speedtest server to use - use 0 for auto-selection')
 flags.DEFINE_boolean('version', False, 'show version')
 FLAGS = flags.FLAGS
 
 
 class PrometheusSpeedtest():
     """Enapsulates behavior performing and reporting results of speedtests."""
-    def __init__(self, source_address=None, timeout=10):
+    def __init__(self, source_address=None, timeout=10, server=0):
         """Instantiates a PrometheusSpeedtest object.
 
         Args:
@@ -32,6 +33,7 @@ class PrometheusSpeedtest():
         """
         self._source_address = source_address
         self._timeout = timeout
+        self._server = server
 
     def test(self):
         """Performs speedtest, returns results.
@@ -42,6 +44,8 @@ class PrometheusSpeedtest():
         logging.info('Performing Speedtest')
         client = speedtest.Speedtest(source_address=self._source_address,
                                      timeout=self._timeout)
+        if self._server > 0:
+            client.get_servers(servers=self._server)
         client.get_best_server()
         client.download()
         client.upload()
@@ -51,13 +55,14 @@ class PrometheusSpeedtest():
 
 class SpeedtestCollector():
     """Performs Speedtests when requested from Prometheus."""
-    def __init__(self, tester=None):
+    def __init__(self, tester=None, server=0):
         """Instantiates a SpeedtestCollector object.
 
         Args:
             tester: An instantiated PrometheusSpeedtest object for testing.
+            server: server-id to use when tester is auto-created
         """
-        self._tester = tester if tester else PrometheusSpeedtest()
+        self._tester = tester if tester else PrometheusSpeedtest(server=server)
 
     def collect(self):
         """Performs a Speedtests and yields metrics.
@@ -121,7 +126,7 @@ def main(argv):
         return
 
     registry = core.CollectorRegistry(auto_describe=False)
-    registry.register(SpeedtestCollector())
+    registry.register(SpeedtestCollector(server=FLAGS.server))
     metrics_handler = SpeedtestMetricsHandler.factory(registry)
 
     http = server.ThreadingHTTPServer((FLAGS.address, FLAGS.port),


### PR DESCRIPTION
To be have less variance in the measurements I'd like to always use the same server and not rely on the auto-detection which sometimes selects pretty bad servers.

Not much python experience here, so hope the PR is ok :)