### PR TITLE
Add snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 .cache/
 # pytype
 .pytype/
+# snap
+*.snap

--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -1,30 +1,28 @@
 #!/usr/bin/python3.7
 """Instrument speedtest.net speedtests from Prometheus."""
 
+import os
 from http import server
 from urllib.parse import urlparse
-import os
 
-from absl import app
-from absl import flags
-from absl import logging
-from prometheus_client import core
 import prometheus_client
 import speedtest
-
+from absl import app, flags, logging
+from prometheus_client import core
 from prometheus_speedtest import version
 
-flags.DEFINE_string('address', '0.0.0.0', 'address to listen on')
-flags.DEFINE_integer('port', 9516, 'port to listen on')
+flags.DEFINE_string("address", "0.0.0.0", "address to listen on")
+flags.DEFINE_integer("port", 9516, "port to listen on")
 flags.DEFINE_list(
-    'servers', None,
-    'speedtest server(s) to use - leave empty for auto-selection')
-flags.DEFINE_boolean('version', False, 'show version')
+    "servers", None, "speedtest server(s) to use - leave empty for auto-selection"
+)
+flags.DEFINE_boolean("version", False, "show version")
 FLAGS = flags.FLAGS
 
 
-class PrometheusSpeedtest():
+class PrometheusSpeedtest:
     """Enapsulates behavior performing and reporting results of speedtests."""
+
     def __init__(self, source_address=None, timeout=10, servers=None):
         """Instantiates a PrometheusSpeedtest object.
 
@@ -43,20 +41,21 @@ class PrometheusSpeedtest():
         Returns:
             speedtest.SpeedtestResults object.
         """
-        logging.info('Performing Speedtest...')
-        client = speedtest.Speedtest(source_address=self._source_address,
-                                     timeout=self._timeout)
-        logging.debug('Eligible servers: %s',
-                      client.get_servers(servers=self._servers))
-        logging.debug('Picked server: %s', client.get_best_server())
+        logging.info("Performing Speedtest...")
+        client = speedtest.Speedtest(
+            source_address=self._source_address, timeout=self._timeout
+        )
+        logging.debug("Eligible servers: %s", client.get_servers(servers=self._servers))
+        logging.debug("Picked server: %s", client.get_best_server())
         client.download()
         client.upload()
-        logging.info('Results: %s', client.results)
+        logging.info("Results: %s", client.results)
         return client.results
 
 
-class SpeedtestCollector():
+class SpeedtestCollector:
     """Performs Speedtests when requested from Prometheus."""
+
     def __init__(self, tester=None, servers=None):
         """Instantiates a SpeedtestCollector object.
 
@@ -64,8 +63,7 @@ class SpeedtestCollector():
             tester: An instantiated PrometheusSpeedtest object for testing.
             servers: servers-id to use when tester is auto-created
         """
-        self._tester = tester if tester else PrometheusSpeedtest(
-            servers=servers)
+        self._tester = tester if tester else PrometheusSpeedtest(servers=servers)
 
     def collect(self):
         """Performs a Speedtests and yields metrics.
@@ -75,36 +73,40 @@ class SpeedtestCollector():
         """
         results = self._tester.test()
 
-        download_speed = core.GaugeMetricFamily('download_speed_bps',
-                                                'Download speed (bit/s)')
+        download_speed = core.GaugeMetricFamily(
+            "download_speed_bps", "Download speed (bit/s)"
+        )
         download_speed.add_metric(labels=[], value=results.download)
         yield download_speed
 
-        upload_speed = core.GaugeMetricFamily('upload_speed_bps',
-                                              'Upload speed (bit/s)')
+        upload_speed = core.GaugeMetricFamily(
+            "upload_speed_bps", "Upload speed (bit/s)"
+        )
         upload_speed.add_metric(labels=[], value=results.upload)
         yield upload_speed
 
-        ping = core.GaugeMetricFamily('ping_ms', 'Latency (ms)')
+        ping = core.GaugeMetricFamily("ping_ms", "Latency (ms)")
         ping.add_metric(labels=[], value=results.ping)
         yield ping
 
-        bytes_received = core.GaugeMetricFamily('bytes_received',
-                                                'Bytes received during test')
+        bytes_received = core.GaugeMetricFamily(
+            "bytes_received", "Bytes received during test"
+        )
         bytes_received.add_metric(labels=[], value=results.bytes_received)
         yield bytes_received
 
-        bytes_sent = core.GaugeMetricFamily('bytes_sent',
-                                            'Bytes sent during test')
+        bytes_sent = core.GaugeMetricFamily("bytes_sent", "Bytes sent during test")
         bytes_sent.add_metric(labels=[], value=results.bytes_sent)
         yield bytes_sent
 
 
-class SpeedtestMetricsHandler(server.SimpleHTTPRequestHandler,
-                              prometheus_client.MetricsHandler):
+class SpeedtestMetricsHandler(
+    server.SimpleHTTPRequestHandler, prometheus_client.MetricsHandler
+):
     """HTTP handler extending MetricsHandler and adding status page support."""
+
     def __init__(self, *args, **kwargs):
-        static_directory = os.path.join(os.path.dirname(__file__), 'static')
+        static_directory = os.path.join(os.path.dirname(__file__), "static")
         # pylint: disable=unexpected-keyword-arg
         super().__init__(directory=static_directory, *args, **kwargs)
         # pylint: enable=unexpected-keyword-arg
@@ -115,9 +117,9 @@ class SpeedtestMetricsHandler(server.SimpleHTTPRequestHandler,
         Requests to '/probe' are handled by prometheus_client.MetricsHandler,
         other requests serve static HTML.
         """
-        logging.info('%s - %s', self.requestline, self.client_address)
+        logging.info("%s - %s", self.requestline, self.client_address)
         path = urlparse(self.path).path
-        if path == '/probe':
+        if path == "/probe":
             prometheus_client.MetricsHandler.do_GET(self)
         else:
             server.SimpleHTTPRequestHandler.do_GET(self)
@@ -127,18 +129,18 @@ def main(argv):
     """Entry point for prometheus_speedtest.py."""
     del argv  # unused
     if FLAGS.version:
-        print('prometheus_speedtest v%s' % version.VERSION)
+        print("prometheus_speedtest v%s" % version.VERSION)
         return
 
     registry = core.CollectorRegistry(auto_describe=False)
     registry.register(SpeedtestCollector(servers=FLAGS.servers))
     metrics_handler = SpeedtestMetricsHandler.factory(registry)
 
-    http = server.ThreadingHTTPServer((FLAGS.address, FLAGS.port),
-                                      metrics_handler)
+    http = server.ThreadingHTTPServer((FLAGS.address, FLAGS.port), metrics_handler)
 
-    logging.info('Starting HTTP server listening on %s:%s', FLAGS.address,
-                 FLAGS.port)
+    logging.info(
+        "Starting HTTP server listening on {}:{}".format(FLAGS.address, FLAGS.port)
+    )
     http.serve_forever()
 
 
@@ -147,5 +149,5 @@ def init():
     app.run(main)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     init()

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 """Build script for setuptools, used to create PyPi package."""
 import os
 
-from setuptools import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 from prometheus_speedtest import version
 
@@ -14,7 +13,7 @@ def read_file(rel_path):
       rel_path: relative file path, string.
     """
     here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, rel_path), 'r') as rel_file:
+    with open(os.path.join(here, rel_path), "r") as rel_file:
         return rel_file.read().strip()
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: prometheus-speedtest
+base: core20
+version: git
+summary: A Prometheus exporter for measuring Internet connection bandwidth
+description: |
+    prometheus-speedtest uses the speedtest.net network of bandwidth measurement
+    servers to measure download and upload bandwidth of an Internet connection
+    at a specific point in time, providing this information to Prometheus.
+
+grade: stable
+confinement: strict
+
+apps:
+  daemon:
+    plugs:
+      - network
+      - network-bind
+    command: bin/prometheus_speedtest
+    daemon: simple
+parts:
+  prometheus-speedtest:
+    plugin: python
+    stage-packages:
+        - python3-venv
+    source: .


### PR DESCRIPTION
This merge does the following:
 - Updates the dependencies in setup.py to match requirements.txt, fixing the setup.py for usage with 3.8
 - Makes a small change to use .format for logging for better compatibility across Python versions
 - Adds snapcraft packaging, to allow the exporter to be built and run as a confined snap package. With this metadata in the repository, snap packages can be built directly from the repo with `snapcraft`, the repository can also be registered with the snap store to enable automatic builds and updates for users who install it from the store.