### PR TITLE
Enabling the server excludes flag to carry through

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ flags:
 prometheus_speedtest.py:
   --address: address to listen on
     (default: '0.0.0.0')
+  --excludes: speedtest server(s) to exclude - leave empty for no exclusion
+    (a comma separated list)
   --port: port to listen on
     (default: '9516')
     (an integer)
+  --servers: speedtest server(s) to use - leave empty for auto-selection
+    (a comma separated list)
   --[no]version: show version
     (default: 'false')
 ```

--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -140,6 +140,10 @@ def main(argv):
         return
 
     registry = core.CollectorRegistry(auto_describe=False)
+    if set(FLAGS.servers).issubset(FLAGS.excludes):
+        logging.fatal(
+            '--servers is a subset of --excludes, no viable test server is configured.  '
+            + 'Ensure excludes does not exclude all servers.')
     registry.register(
         SpeedtestCollector(servers=FLAGS.servers, excludes=FLAGS.excludes))
     metrics_handler = SpeedtestMetricsHandler.factory(registry)


### PR DESCRIPTION
This PR allows specifying the exclude server flag to specify a server to not use. 
The use case I have for this is explained in PR #29, where I want to monitor both my ISP's network, and test it going to the closest non ISP test point.
This is better than #29 since it doesn't change the data in prometheus.  In order for me to report on this in Grafana, I'm separating my ISP data and my non-ISP data using annotations from my Kubernetes deploy.  I figure since this is a special, non-standard use case, this would be best for all parties.