### PR TITLE
prometheus_speedtest: Fix exception raised when server/exclude flags aren't set.

### DIFF
--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -17,10 +17,10 @@ from prometheus_speedtest import version
 flags.DEFINE_string('address', '0.0.0.0', 'address to listen on')
 flags.DEFINE_integer('port', 9516, 'port to listen on')
 flags.DEFINE_list(
-    'servers', None,
+    'servers', [],
     'speedtest server(s) to use - leave empty for auto-selection')
 flags.DEFINE_list(
-    'excludes', None,
+    'excludes', [],
     'speedtest server(s) to exclude - leave empty for no exclusion')
 flags.DEFINE_boolean('version', False, 'show version')
 FLAGS = flags.FLAGS
@@ -140,10 +140,10 @@ def main(argv):
         return
 
     registry = core.CollectorRegistry(auto_describe=False)
-    if set(FLAGS.servers).issubset(FLAGS.excludes):
+    if FLAGS.servers and set(FLAGS.excludes).issuperset(FLAGS.servers):
         logging.fatal(
-            '--servers is a subset of --excludes, no viable test server is configured.  '
-            + 'Ensure excludes does not exclude all servers.')
+            '--excludes is a superset of --includes, no viable test server is '
+            'possible. Ensure --excludes does not contain all --servers.')
     registry.register(
         SpeedtestCollector(servers=FLAGS.servers, excludes=FLAGS.excludes))
     metrics_handler = SpeedtestMetricsHandler.factory(registry)


### PR DESCRIPTION
Bug accidentally introduced in #30.