### PR TITLE
Fix build failure by PEP 597 warning in pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read_file(rel_path):
       rel_path: relative file path, string.
     """
     here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, rel_path), 'r') as rel_file:
+    with open(os.path.join(here, rel_path), 'r', encoding='utf-8') as rel_file:
         return rel_file.read().strip()
 
 


### PR DESCRIPTION
[PEP 597](https://www.python.org/dev/peps/pep-0597/) adds an additional warning when using open() without specifying an explicit encoding. This was added to pylint in https://github.com/PyCQA/pylint/issues/3826 and eventually broke our build as a new warning.