### PR TITLE
pytpe: Add return type hints to all return values, including __init__ calls.

### DIFF
--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -36,7 +36,7 @@ class PrometheusSpeedtest():
                  source_address: Optional[str] = None,
                  timeout: int = 10,
                  servers: Optional[Sequence[str]] = None,
-                 excludes: Optional[Sequence[str]] = None):
+                 excludes: Optional[Sequence[str]] = None) -> None:
         """Instantiates a PrometheusSpeedtest object.
 
         Args:
@@ -51,7 +51,7 @@ class PrometheusSpeedtest():
         self._servers = servers
         self._excludes = excludes
 
-    def test(self):
+    def test(self) -> speedtest.SpeedtestResults:
         """Performs speedtest, returns results.
 
         Returns:
@@ -76,7 +76,7 @@ class SpeedtestCollector():
     def __init__(self,
                  tester: Optional[PrometheusSpeedtest] = None,
                  servers: Optional[Sequence[str]] = None,
-                 excludes: Optional[Sequence[str]] = None):
+                 excludes: Optional[Sequence[str]] = None) -> None:
         """Instantiates a SpeedtestCollector object.
 
         Args:
@@ -86,7 +86,7 @@ class SpeedtestCollector():
         self._tester = tester if tester else PrometheusSpeedtest(
             servers=servers, excludes=excludes)
 
-    def collect(self):
+    def collect(self) -> core.Metric:
         """Performs a Speedtests and yields metrics.
 
         Yields:
@@ -123,13 +123,13 @@ class SpeedtestMetricsHandler(server.SimpleHTTPRequestHandler,
                               prometheus_client.MetricsHandler):
     """HTTP handler extending MetricsHandler and adding status page support."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         static_directory = os.path.join(os.path.dirname(__file__), 'static')
         # pylint: disable=unexpected-keyword-arg
         super().__init__(directory=static_directory, *args, **kwargs)
         # pylint: enable=unexpected-keyword-arg
 
-    def do_GET(self):
+    def do_GET(self) -> None:
         """Handles HTTP GET requests.
 
         Requests to '/probe' are handled by prometheus_client.MetricsHandler,


### PR DESCRIPTION
According to PEP 484:

    The return type of __init__ ought to be annotated with -> None. The
    reason for this is subtle. If __init__ assumed a return annotation
    of -> None, would that mean that an argument-less, un-annotated
    __init__ method should still be type-checked? Rather than leaving
    this ambiguous or introducing an exception to the exception, we
    simply say that __init__ ought to have a return annotation; the
    default behavior is thus the same as for other methods.