### PR TITLE
travis: Add setuptools packaging step to Travis analysis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
   # Issue #19
   - python -c 'from prometheus_speedtest import prometheus_speedtest as p; p.FLAGS.version = True; p.init()'
   - pre-commit run -a
+  - python setup.py sdist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ pre-commit==2.19.0
 pylint==2.14.4
 pytest==7.1.2
 pytype==2022.6.30
+setuptools==62.6.0
 yapf==0.32.0


### PR DESCRIPTION
Ensures that we are able to build and package prometheus_speedtest to PyPi.