### PR TITLE
Force secure connection to speedtest.net

### DIFF
--- a/prometheus_speedtest/prometheus_speedtest.py
+++ b/prometheus_speedtest/prometheus_speedtest.py
@@ -59,7 +59,7 @@ class PrometheusSpeedtest():
         """
         logging.info('Performing Speedtest...')
         client = speedtest.Speedtest(source_address=self._source_address,
-                                     timeout=self._timeout)
+                                     timeout=self._timeout, secure=True)
         logging.debug(
             'Eligible servers: %s',
             client.get_servers(servers=self._servers, exclude=self._excludes))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 mock==4.0.3
-pre-commit==2.19.0
-pylint==2.14.4
+#pre-commit==2.19.0
+#pylint==2.14.4
 pytest==7.1.2
 pytype==2022.6.30
 setuptools==62.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 mock==4.0.3
-#pre-commit==2.19.0
-#pylint==2.14.4
+pre-commit==2.19.0
+pylint==2.14.4
 pytest==7.1.2
 pytype==2022.6.30
 setuptools==62.6.0

--- a/tests/prometheus_speedtest_test.py
+++ b/tests/prometheus_speedtest_test.py
@@ -22,7 +22,7 @@ class PrometheusSpeedtestTest(unittest.TestCase):
     def test_test(self, mock_speedtest):
         """Ensures correctness of PrometheusSpeedtest.test()."""
         tester = prometheus_speedtest.PrometheusSpeedtest(
-            source_address='4.3.2.1', timeout=10)
+            source_address='4.3.2.1', timeout=10, secure=True)
 
         expected = PrometheusSpeedtestTest._results(10, 5, 30)
         mock_speedtest.return_value.results = expected
@@ -30,7 +30,7 @@ class PrometheusSpeedtestTest(unittest.TestCase):
         self.assertEqual(tester.test(), expected)
 
         mock_speedtest.assert_called_once_with(source_address='4.3.2.1',
-                                               timeout=10)
+                                               timeout=10, secure=True)
         mock_speedtest.return_value.get_best_server.assert_called_once_with()
         mock_speedtest.return_value.download.assert_called_once_with()
         mock_speedtest.return_value.upload.assert_called_once_with()

--- a/tests/prometheus_speedtest_test.py
+++ b/tests/prometheus_speedtest_test.py
@@ -22,7 +22,7 @@ class PrometheusSpeedtestTest(unittest.TestCase):
     def test_test(self, mock_speedtest):
         """Ensures correctness of PrometheusSpeedtest.test()."""
         tester = prometheus_speedtest.PrometheusSpeedtest(
-            source_address='4.3.2.1', timeout=10, secure=True)
+            source_address='4.3.2.1', timeout=10)
 
         expected = PrometheusSpeedtestTest._results(10, 5, 30)
         mock_speedtest.return_value.results = expected


### PR DESCRIPTION
It seems that the speedtest servers return random 403 errors when the speedtest client uses http. Forcing the client to use https fixes this and I no longer see the exception being thrown in my logs after running for some time.

```
Exception happened during processing of request from ('<redacted>', 37976)
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/local/lib/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/prometheus_speedtest/prometheus_speedtest.py", line 125, in __init__
    super().__init__(directory=static_directory, *args, **kwargs)
  File "/usr/local/lib/python3.7/http/server.py", line 646, in __init__
    super().__init__(*args, **kwargs)
  File "/usr/local/lib/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/local/lib/python3.7/http/server.py", line 426, in handle
    self.handle_one_request()
  File "/usr/local/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/prometheus_speedtest/prometheus_speedtest.py", line 137, in do_GET
    prometheus_client.MetricsHandler.do_GET(self)
  File "/usr/local/lib/python3.7/site-packages/prometheus_client/exposition.py", line 169, in do_GET
    status, header, output = _bake_output(registry, accept_header, params)
  File "/usr/local/lib/python3.7/site-packages/prometheus_client/exposition.py", line 40, in _bake_output
    output = encoder(registry)
  File "/usr/local/lib/python3.7/site-packages/prometheus_client/openmetrics/exposition.py", line 14, in generate_latest
    for metric in registry.collect():
  File "/usr/local/lib/python3.7/site-packages/prometheus_client/registry.py", line 82, in collect
    for metric in collector.collect():
  File "/prometheus_speedtest/prometheus_speedtest.py", line 92, in collect
    results = self._tester.test()
  File "/prometheus_speedtest/prometheus_speedtest.py", line 60, in test
    timeout=self._timeout)
  File "/usr/local/lib/python3.7/site-packages/speedtest.py", line 1095, in __init__
    self.get_config()
  File "/usr/local/lib/python3.7/site-packages/speedtest.py", line 1127, in get_config
    raise ConfigRetrievalError(e)
speedtest.ConfigRetrievalError: HTTP Error 403: Forbidden
```